### PR TITLE
Creating a trustore for a certificate

### DIFF
--- a/files/InstallCert/InstallCert.java
+++ b/files/InstallCert/InstallCert.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright 2006 Sun Microsystems, Inc.  All Rights Reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   - Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   - Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ *   - Neither the name of Sun Microsystems nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/**
+ * Originally from:
+ * http://blogs.sun.com/andreas/resource/InstallCert.java
+ * Use:
+ * java InstallCert hostname
+ * Example:
+ *% java InstallCert ecc.fedora.redhat.com
+ */
+
+import javax.net.ssl.*;
+import java.io.*;
+import java.security.KeyStore;
+import java.security.MessageDigest;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+
+/**
+ * Class used to add the server's certificate to the KeyStore
+ * with your trusted certificates.
+ */
+public class InstallCert {
+
+    public static void main(String[] args) throws Exception {
+        String host;
+        int port;
+        char[] passphrase;
+	char SEP = File.separatorChar;
+	String jssc = System.getProperty("java.home") + SEP + "lib" + SEP + "security" + SEP + "jssecacerts";
+
+        if ((args.length == 1) || (args.length == 2)) {
+            String[] c = args[0].split(":");
+            host = c[0];
+            port = (c.length == 1) ? 443 : Integer.parseInt(c[1]);
+            String p = (args.length == 1) ? "changeit" : args[1];
+            passphrase = p.toCharArray();
+        } else {
+            System.out.println("Usage: java InstallCert [:port] [passphrase]");
+            return;
+        }
+
+
+
+        File file = new File(jssc);
+        if (file.isFile() == false) {
+            File dir = new File(System.getProperty("java.home") + SEP
+                    + "lib" + SEP + "security");
+            file = new File(dir, jssc);
+            if (file.isFile() == false) {
+                file = new File(dir, "cacerts");
+            }
+        }
+        System.out.println("Loading KeyStore " + file + "...");
+        InputStream in = new FileInputStream(file);
+        KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
+        ks.load(in, passphrase);
+        in.close();
+
+        SSLContext context = SSLContext.getInstance("TLS");
+        TrustManagerFactory tmf =
+                TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+        tmf.init(ks);
+        X509TrustManager defaultTrustManager = (X509TrustManager) tmf.getTrustManagers()[0];
+        SavingTrustManager tm = new SavingTrustManager(defaultTrustManager);
+        context.init(null, new TrustManager[]{tm}, null);
+        SSLSocketFactory factory = context.getSocketFactory();
+
+        System.out.println("Opening connection to " + host + ":" + port + "...");
+        SSLSocket socket = (SSLSocket) factory.createSocket(host, port);
+        socket.setSoTimeout(10000);
+        try {
+            System.out.println("Starting SSL handshake...");
+            socket.startHandshake();
+            socket.close();
+            System.out.println();
+            System.out.println("No errors, certificate is already trusted");
+        } catch (SSLException e) {
+            System.out.println();
+            e.printStackTrace(System.out);
+        }
+
+        X509Certificate[] chain = tm.chain;
+        if (chain == null) {
+            System.out.println("Could not obtain server certificate chain");
+            return;
+        }
+
+        BufferedReader reader =
+                new BufferedReader(new InputStreamReader(System.in));
+
+        System.out.println();
+        System.out.println("Server sent " + chain.length + " certificate(s):");
+        System.out.println();
+        MessageDigest sha1 = MessageDigest.getInstance("SHA1");
+        MessageDigest md5 = MessageDigest.getInstance("MD5");
+        for (int i = 0; i < chain.length; i++) {
+            X509Certificate cert = chain[i];
+            System.out.println
+                    (" " + (i + 1) + " Subject " + cert.getSubjectDN());
+            System.out.println("   Issuer  " + cert.getIssuerDN());
+            sha1.update(cert.getEncoded());
+            System.out.println("   sha1    " + toHexString(sha1.digest()));
+            md5.update(cert.getEncoded());
+            System.out.println("   md5     " + toHexString(md5.digest()));
+            System.out.println();
+        }
+
+        System.out.println("Enter certificate to add to trusted keystore or 'q' to quit: [1]");
+        String line = "1";
+        int k;
+        try {
+            k = (line.length() == 0) ? 0 : Integer.parseInt(line) - 1;
+        } catch (NumberFormatException e) {
+            System.out.println("KeyStore not changed");
+            return;
+        }
+
+        X509Certificate cert = chain[k];
+        String alias = host + "-" + (k + 1);
+        ks.setCertificateEntry(alias, cert);
+
+        OutputStream out = new FileOutputStream(jssc);
+        ks.store(out, passphrase);
+        out.close();
+
+        System.out.println();
+        System.out.println(cert);
+        System.out.println();
+        System.out.println
+                ("Added certificate to keystore 'jssecacerts' using alias '"
+                        + alias + "'");
+    }
+
+    private static final char[] HEXDIGITS = "0123456789abcdef".toCharArray();
+
+    private static String toHexString(byte[] bytes) {
+        StringBuilder sb = new StringBuilder(bytes.length * 3);
+        for (int b : bytes) {
+            b &= 0xff;
+            sb.append(HEXDIGITS[b >> 4]);
+            sb.append(HEXDIGITS[b & 15]);
+            sb.append(' ');
+        }
+        return sb.toString();
+    }
+
+    private static class SavingTrustManager implements X509TrustManager {
+
+        private final X509TrustManager tm;
+        private X509Certificate[] chain;
+
+        SavingTrustManager(X509TrustManager tm) {
+            this.tm = tm;
+        }
+
+        public X509Certificate[] getAcceptedIssuers() {
+	   
+	    /** 
+	     * This change has been done due to the following resolution advised for Java 1.7+
+		http://infposs.blogspot.kr/2013/06/installcert-and-java-7.html
+       	     **/ 
+	    
+	    return new X509Certificate[0];	
+            //throw new UnsupportedOperationException();
+        }
+
+        public void checkClientTrusted(X509Certificate[] chain, String authType)
+                throws CertificateException {
+            throw new UnsupportedOperationException();
+        }
+
+        public void checkServerTrusted(X509Certificate[] chain, String authType)
+                throws CertificateException {
+            this.chain = chain;
+            tm.checkServerTrusted(chain, authType);
+        }
+    }
+}

--- a/manifests/create-truststore.pp
+++ b/manifests/create-truststore.pp
@@ -1,0 +1,27 @@
+class java::create-truststore($hostname = '', $port = 443, $passphrase = ''){
+
+  file {"/usr/java/default/lib/InstallCert.java":
+    source => "puppet:///modules/java/InstallCert/InstallCert.java",
+    owner => "root",
+    group => "root",
+    mode => 0644
+  }
+
+  exec {"Compile InstallCert.java":
+    command => "javac InstallCert.java",
+    cwd => "/usr/java/default/lib/",
+    path => "/usr/java/default/bin:/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin",
+    subscribe => File["/usr/java/default/lib/InstallCert.java"],
+    environment => ["JAVA_HOME=/usr/java/default/"],
+    creates => "/usr/java/default/lib/InstallCert.class",
+    require => File["/usr/java/default/lib/InstallCert.java"],
+  } ->
+
+  exec {"create-trustore":
+    command => "java InstallCert $hostname:$port $passphrase",
+    cwd => "/usr/java/default/lib",
+    environment => ["JAVA_HOME=/usr/java/default/"],
+    path => "/usr/java/default/bin:/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin",
+  }
+}
+

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -88,4 +88,18 @@ class java (
     target  => "/usr/java/jdk1.${java_major_version}.0_${java_minor_version}",
     require => Package["jdk 1.${java_major_version}.0_${java_minor_version}-fcs"]
   }
+  $fetch_cert = hiera_hash('java::fetch_certificate', undef)
+  if ( $fetch_cert) {
+    $_hostname = keys($fetch_cert)
+    $_pass = $fetch_cert["$_hostname"][key]
+    $_port = $fetch_cert["$_hostname"][port]
+    notice($_port)
+      class { 'java::create-truststore':
+       hostname => $_hostname,
+       port => $_port,
+       passphrase => $_pass,
+       require => File["/usr/java/default"]
+     }
+  }
+
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -88,18 +88,17 @@ class java (
     target  => "/usr/java/jdk1.${java_major_version}.0_${java_minor_version}",
     require => Package["jdk 1.${java_major_version}.0_${java_minor_version}-fcs"]
   }
-  $fetch_cert = hiera_hash('java::fetch_certificate', undef)
-  if ( $fetch_cert) {
+  $fetch_cert = hiera_hash('java::create_truststore', undef)
+  if ($fetch_cert) {
     $_hostname = keys($fetch_cert)
     $_pass = $fetch_cert["$_hostname"][key]
     $_port = $fetch_cert["$_hostname"][port]
-    notice($_port)
-      class { 'java::create-truststore':
-       hostname => $_hostname,
-       port => $_port,
-       passphrase => $_pass,
-       require => File["/usr/java/default"]
-     }
+    class { 'java::create-truststore':
+      hostname => $_hostname,
+      port => $_port,
+      passphrase => $_pass,
+      require => File["/usr/java/default"]
+    }
   }
 
 }


### PR DESCRIPTION
The wildcard certificate for *.moneysupermarket.com isn't trusted by Java > 6.
This helps a mesos-slave to create a truststore containing that SSL cert so that slave containers can connect to the jenkins master using SSL